### PR TITLE
Add a flag to download weight maps from legacy

### DIFF
--- a/src/everystamp/downloaders.py
+++ b/src/everystamp/downloaders.py
@@ -342,8 +342,6 @@ class LegacyDownloader(FileDownloader):
     def download(self, **kwargs):
         if kwargs["mode"] == "both":
             furl = self.format_url(**kwargs)
-            if kwargs["get_weightmap"]:
-                furl = f"{furl:s}&invvar"
             self.logger.info("Downloading cutout from %s", furl)
             if not kwargs["ddir"]:
                 self.logger.info(
@@ -368,6 +366,8 @@ class LegacyDownloader(FileDownloader):
             self.download_file(furl, filename=fname, target_dir=ddir)
         else:
             furl = self.format_url(**kwargs)
+            if kwargs["get_weightmap"]:
+                furl = f"{furl:s}&invvar"
             self.logger.info("Downloading cutout from %s", furl)
             if not kwargs["ddir"]:
                 self.logger.info(
@@ -377,12 +377,21 @@ class LegacyDownloader(FileDownloader):
                 ddir = os.getcwd()
             else:
                 ddir = kwargs["ddir"]
-            fname = "legacystamps_{ra:f}_{dec:f}_{layer:s}.{mode:s}".format(
-                ra=kwargs["ra"],
-                dec=kwargs["dec"],
-                layer=kwargs["layer"],
-                mode=kwargs["mode"],
-            )
+
+            if kwargs["get_weightmap"]:
+                fname = "legacystamps_{ra:f}_{dec:f}_{layer:s}.invvar.{mode:s}".format(
+                    ra=kwargs["ra"],
+                    dec=kwargs["dec"],
+                    layer=kwargs["layer"],
+                    mode=kwargs["mode"],
+                )
+            else:
+                fname = "legacystamps_{ra:f}_{dec:f}_{layer:s}.{mode:s}".format(
+                    ra=kwargs["ra"],
+                    dec=kwargs["dec"],
+                    layer=kwargs["layer"],
+                    mode=kwargs["mode"],
+                )
         try:
             self.download_file(furl, filename=fname, target_dir=ddir)
         except requests.exceptions.HTTPError:

--- a/src/everystamp/downloaders.py
+++ b/src/everystamp/downloaders.py
@@ -342,6 +342,8 @@ class LegacyDownloader(FileDownloader):
     def download(self, **kwargs):
         if kwargs["mode"] == "both":
             furl = self.format_url(**kwargs)
+            if kwargs["get_weightmap"]:
+                furl = f"{furl:s}&invvar"
             self.logger.info("Downloading cutout from %s", furl)
             if not kwargs["ddir"]:
                 self.logger.info(

--- a/src/everystamp/everystamp.py
+++ b/src/everystamp/everystamp.py
@@ -150,6 +150,13 @@ def _add_args_download(parser):
         action="store_true",
         help="Automatically change the pixel size if the resulting image would exceed the server maximum of 3000x3000 pixels.",
     )
+    legacy_args.add_argument(
+        "--legacy_weightmap",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Download the weight map for the requested band instead of the image itself.",
+    )
 
     ps_args = parser.add_argument_group("[Pan-STARRS]")
     ps_args.add_argument(
@@ -866,6 +873,7 @@ def _process_args_download(args):
                 layer=args.legacy_layer,
                 autoscale=args.legacy_autoscale,
                 ddir=args.ddir,
+                get_weightmap=args.legacy_weightmap,
             )
         elif args.survey == "pan-starrs":
             from everystamp.downloaders import PanSTARRSDownloader
@@ -1348,7 +1356,8 @@ def _process_args_composite(args):
     x = nx / 2
     y = ny / 2
     wcs = WCS(header_fg)
-    ra, dec = wcs.wcs_pix2world(x, y, 1)
+    # ra, dec = wcs.wcs_pix2world(x, y, 1)
+    ra, dec = wcs.wcs_pix2world(x, y, 0)
 
     pos = SkyCoord(ra, dec, unit="deg")
     bp = BlendPlot(

--- a/src/everystamp/everystamp.py
+++ b/src/everystamp/everystamp.py
@@ -15,11 +15,9 @@ import astropy.units as units
 import astropy.visualization
 import cv2  # type: ignore
 import numpy as np
-import requests
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.wcs import WCS
-from astroquery.skyview import SkyView  # type: ignore
 from everystamp.cutters import make_cutout_2D, make_cutout_2D_fast, make_cutout_region
 from everystamp.tonemapping import lhdr, normalise
 from everystamp.tonemapping.stretches import TimmermanStretch


### PR DESCRIPTION
# Description

This adds a `--legacy_weightmap` option to download the inverse variance maps for Legacy images alongside the usual FITS image.